### PR TITLE
build: 增加build命令 & 修复图片不展示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>
-    <img width="284" src="https://github.com/iceqing/react-amis-admin/raw/master/docs/logo_react-amid-admin.png">
+    <img width="284" src="https://github.com/iceqing/react-amis-admin/raw/vite/docs/logo_react-amid-admin.png">
   </p>
 
 [react-amis-admin在线文档](https://docs.amis.iceq.cc) |

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "npm run vite",
     "vite": "vite",
     "vite-build": "vite build",
+    "build": "vite build",
     "postinstall": "patch-package"
   },
   "keywords": [


### PR DESCRIPTION
之前的master分支改名为webpack分支，现在默认将vite3作为默认分支，这样可以提升开发时页面刷新速度。


有什么问题也欢迎大家提意见。